### PR TITLE
Avoid unnecessary verifications

### DIFF
--- a/runner/src/glide/runner/commnads/GradleTaskCommand.groovy
+++ b/runner/src/glide/runner/commnads/GradleTaskCommand.groovy
@@ -21,7 +21,7 @@ class GradleTaskCommand implements Command {
         def sync = new SyncService(runtime, ant)
 
         if (runtime.config.glide?.configure instanceof Closure)
-            runtime.config.glide?.configure?.call(runtime, sync.synchronizer)
+            runtime.config.glide?.configure.call(runtime, sync.synchronizer)
 
         sync.start()
         def gradle = new GradleProjectRunner(runtime.outputApp.dir)


### PR DESCRIPTION
Hi Kunal!
if (configure instanceof Closure) return true we don't need to use safe navigation to run the call() method.