### PR TITLE
Updates the install manual to reference sdkman tool name over the older gvm name.

### DIFF
--- a/site/app/docs/installing.md
+++ b/site/app/docs/installing.md
@@ -9,11 +9,11 @@ environment variable.
 
 If you use an OS that flaunts a decent Terminal app with `bash` you can choose one of the following three methods:
 
-- ### Using GVM
+- ### Using SDKMAN!
 
-    If you have [gvm](http://gvmtool.net/) installed, you are just this command away from glide:
+    If you have [sdk](http://sdkman.io/) installed, you are just this command away from glide:
 
-        $ gvm install glide
+        $ sdk install glide
 
 
 - ### Using nixstall


### PR DESCRIPTION
First patch to another project and found glide through sdkman.  Saw the install page references the gvm name and thought it would be good to keep up to date.  I raised issue-24 in the project to reflect the alteration.